### PR TITLE
Added timeout (12 mins) for unresponsive server after successful login

### DIFF
--- a/src/main/java/org/powertac/samplebroker/ContextManagerService.java
+++ b/src/main/java/org/powertac/samplebroker/ContextManagerService.java
@@ -15,29 +15,16 @@
  */
 package org.powertac.samplebroker;
 
-import java.util.Arrays;
-
 import org.apache.log4j.Logger;
-import org.joda.time.Instant;
 import org.powertac.common.BankTransaction;
 import org.powertac.common.CashPosition;
 import org.powertac.common.Competition;
-import org.powertac.common.CustomerInfo;
-import org.powertac.common.Timeslot;
-import org.powertac.common.msg.BrokerAccept;
 import org.powertac.common.msg.DistributionReport;
-import org.powertac.common.msg.SimEnd;
-import org.powertac.common.msg.SimPause;
-import org.powertac.common.msg.SimResume;
-import org.powertac.common.msg.SimStart;
-import org.powertac.common.msg.TimeslotComplete;
-import org.powertac.common.msg.TimeslotUpdate;
-import org.powertac.samplebroker.core.MessageDispatcher;
-import org.powertac.samplebroker.core.PowerTacBroker;
 import org.powertac.samplebroker.interfaces.BrokerContext;
 import org.powertac.samplebroker.interfaces.Initializable;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.util.Arrays;
 
 /**
  * Handles incoming context and bank messages with example behaviors. 

--- a/src/main/java/org/powertac/samplebroker/core/BrokerTournamentService.java
+++ b/src/main/java/org/powertac/samplebroker/core/BrokerTournamentService.java
@@ -15,16 +15,8 @@
  */
 package org.powertac.samplebroker.core;
 
-import java.io.InputStream;
-import java.net.URL;
-import java.net.URLConnection;
-import java.util.Date;
-
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import net.sf.json.JSONObject;
 import net.sf.json.JSONSerializer;
-
 import org.apache.commons.io.IOUtils;
 import org.apache.log4j.Logger;
 import org.powertac.common.config.ConfigurableValue;
@@ -32,6 +24,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.Date;
 /**
  * @author Erik Onarheim
  */
@@ -164,7 +163,7 @@ public class BrokerTournamentService
           serverQueueName = checkServerQueue;
           log.info("serverQueueName=" + checkServerQueue);
 
-          System.out.printf("Login message receieved!\n  jmsUrl=%s\n  queueName=%s\n  serverQueue=%s\n",
+          System.out.printf("Login message received!\n  jmsUrl=%s\n  queueName=%s\n  serverQueue=%s\n",
                             checkJmsUrl, checkBrokerQueue, checkServerQueue);
           return true;
         }

--- a/src/main/java/org/powertac/samplebroker/core/JmsManagementService.java
+++ b/src/main/java/org/powertac/samplebroker/core/JmsManagementService.java
@@ -15,16 +15,6 @@
  */
 package org.powertac.samplebroker.core;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.Executor;
-
-import javax.annotation.Resource;
-import javax.jms.Connection;
-import javax.jms.ConnectionFactory;
-import javax.jms.MessageListener;
-import javax.jms.Session;
-
 import org.apache.activemq.ActiveMQConnectionFactory;
 import org.apache.activemq.pool.PooledConnectionFactory;
 import org.apache.log4j.Logger;
@@ -34,6 +24,12 @@ import org.springframework.jms.connection.CachingConnectionFactory;
 import org.springframework.jms.listener.AbstractMessageListenerContainer;
 import org.springframework.jms.listener.DefaultMessageListenerContainer;
 import org.springframework.stereotype.Service;
+
+import javax.annotation.Resource;
+import javax.jms.*;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Executor;
 
 /**
  * 
@@ -106,7 +102,7 @@ public class JmsManagementService {
     container.setTaskExecutor(taskExecutor);
     container.afterPropertiesSet();
     container.start();
-    
+
     listenerContainerMap.put(listener, container);
   }
 


### PR DESCRIPTION
There was already a wait timeout for when the server became unresponsive.
But this was ignored when the game hadn't started yet (index == 0) because waiting for other brokers to log in might take longer than maxWait.

So when the server stopped while still waiting for brokers, the already logged in brokers would never reset.
