### PR TITLE
Added timeout (12 mins) for unresponsive server after successful login

### DIFF
--- a/src/main/java/org/powertac/samplebroker/core/PowerTacBroker.java
+++ b/src/main/java/org/powertac/samplebroker/core/PowerTacBroker.java
@@ -534,17 +534,26 @@ implements BrokerContext
   synchronized int waitForActivation (int index)
   {
     try {
+      int remainingTimeouts = 6; // Wait max 12 mins == 6 * maxWait
       while (running && (timeslotCompleted <= index)) {
         long maxWait = 120000;
         long nowStamp = System.currentTimeMillis();
         wait(maxWait);
         long diff = System.currentTimeMillis() - nowStamp;
-        if (diff >= maxWait && index != 0) {
+        if (diff >= maxWait) {
+          if (index != 0) {
           String msg = "worker thread waited more than "
               + maxWait / 1000 +" secs for server, abandoning game";
           System.out.println("\n" + msg +"\n");
           log.warn(msg);
           running = false;
+          } else if (--remainingTimeouts <= 0) {
+            String msg = "worker thread waited more than "
+                + "720 secs for server, abandoning game";
+            System.out.println("\n" + msg + "\n");
+            log.warn(msg);
+            running = false;
+          }
         }
       }
     }


### PR DESCRIPTION
There's already a timeout for when the server becomes unresponsive.
But this only works after the game started.
