### PR TITLE
Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ hs_err_pid*
 /target/
 /log/
 *~
+
+# Intellij
+.idea
+*.iml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM maven:3-openjdk-11 AS build
+WORKDIR /opt/powertac/sample-broker/build
+COPY . .
+RUN mvn clean package
+
+FROM openjdk:11-jre-slim
+ENV BROKER_JAR=sample-broker-1.9.0.jar
+WORKDIR /opt/powertac/sample-broker
+COPY --from=build /opt/powertac/sample-broker/build/target/${BROKER_JAR} ./sample-broker.jar
+ENTRYPOINT ["java", "-jar", "/opt/powertac/sample-broker/sample-broker.jar"]

--- a/pom.xml
+++ b/pom.xml
@@ -15,12 +15,12 @@
   <parent>
     <groupId>org.powertac</groupId>
     <artifactId>powertac-parent</artifactId>
-    <version>1.9.0-SNAPSHOT</version>
+    <version>1.9.0</version>
     <relativePath />
   </parent>
 
   <properties>
-    <powertac.version>1.9.0-SNAPSHOT</powertac.version>
+    <powertac.version>1.9.0</powertac.version>
     <exec.args></exec.args>
     <syst.args></syst.args>
   </properties>


### PR DESCRIPTION
Changes (other than the addition of the `Dockerfile`) include:
- set parent pom version to 1.9.0 due to availablity issues of 1.9.0-SNAPSHOT
- added IntelliJ-specific configuration to `.gitignore`

A new image can be created by running the following command:
```shell
docker build -t <NAME>:<VERSION> <PROJECT_ROOT_PATH>
```
- `<NAME>` is the name of the image, oftentimes preceded by an optional namespace; `powertac/sample-broker` would be an example of that.
- `<VERSION>` is the version of the specific image; defaults to `latest`, if I remember correctly.
- `<PROJECT_ROOT_PATH>` is the (relative) path to the directory that contains the `Dockerfile` and is used as the build context, e.g. for copying files that should be available inside the container.

To build the latest version of the Sample Broker from the project root, the command would look like this:
```shell
docker build -t powertac/sample-broker:latest .
```